### PR TITLE
Fix variable name mismatch

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -178,8 +178,8 @@ function saml_slo() {
 			$nameId = null;
 			$sessionIndex = null;
 			$nameIdFormat = null;
-			$samlNameIdNameQualifier = null;
-			$samlNameIdSPNameQualifier = null;
+			$nameIdNameQualifier = null;
+			$nameIdSPNameQualifier = null;
 
 			if (isset($_COOKIE[SAML_NAMEID_COOKIE])) {
 				$nameId = sanitize_text_field($_COOKIE[SAML_NAMEID_COOKIE]);


### PR DESCRIPTION
Fixes #130 - variable name mismatch causing php warnings sent before http headers